### PR TITLE
Fix unsupported operand types error in cron commands

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -32,7 +32,7 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
 
         foreach ($jobs as $name => $job) {
             /* @var $job Mage_Core_Model_Config_Element */
-            $table[$name] = array('Job'  => $name) + $this->getSchedule($job);
+            $table[$name] = array('Job'  => $name) + (array) $this->getSchedule($job);
         }
 
         ksort($table, SORT_STRING);


### PR DESCRIPTION
Runnnig cron related commands such us:
```
$ n98-magerun.phar sys:cron:list
```
or
```
$ n98-magerun.phar sys:cron:run
```

throws a PHP fatal error:
> PHP Fatal error:  Unsupported operand types in phar:///usr/local/bin/n98-magerun.phar/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php on line 35
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/n98-magerun.phar:0
PHP   2. N98\Magento\Application->run() /usr/local/bin/n98-magerun.phar:8
PHP   3. Symfony\Component\Console\Application->run() phar:///usr/local/bin/n98-magerun.phar/src/N98/Magento/Application.php:656
PHP   4. N98\Magento\Application->doRun() phar:///usr/local/bin/n98-magerun.phar/vendor/symfony/console/Application.php:126
PHP   5. Symfony\Component\Console\Application->doRun() phar:///usr/local/bin/n98-magerun.phar/src/N98/Magento/Application.php:595
PHP   6. Symfony\Component\Console\Application->doRunCommand() phar:///usr/local/bin/n98-magerun.phar/vendor/symfony/console/Application.php:195
PHP   7. N98\Magento\Command\AbstractMagentoCommand->run() phar:///usr/local/bin/n98-magerun.phar/vendor/symfony/console/Application.php:886
PHP   8. Symfony\Component\Console\Command\Command->run() phar:///usr/local/bin/n98-magerun.phar/src/N98/Magento/Command/AbstractMagentoCommand.php:431
PHP   9. N98\Magento\Command\System\Cron\RunCommand->execute() phar:///usr/local/bin/n98-magerun.phar/vendor/symfony/console/Command/Command.php:259
PHP  10. N98\Magento\Command\System\Cron\AbstractCronCommand->getJobs() phar:///usr/local/bin/n98-magerun.phar/src/N98/Magento/Command/System/Cron/RunCommand.php:48

The error has been noticed on the OSX El-Captain with the following PHP build:
> PHP 5.6.17 (cli) (built: Jan 17 2016 23:08:15) 
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies
    with Xdebug v2.3.3, Copyright (c) 2002-2015, by Derick Rethans

magerun has been installed step-by-step using the README instructions.